### PR TITLE
修正复合数字格式与无转义符引号读取

### DIFF
--- a/snbtlib/formatter.py
+++ b/snbtlib/formatter.py
@@ -194,7 +194,7 @@ def NumberBuilder(r):
     s = StringIO()
     s.write(r.get_point())
     while i := r.next():
-        if i in ',\n' or i.isspace():
+        if i in '},\n' or i.isspace():
             r.last()
             break
         s.write(i)
@@ -233,9 +233,15 @@ def KeyBuilder(token, r):
                     s = f'"{s}"'
                     break
                 else:
-                    r.last()
-                    token.type = Token.STRING
-                    break
+                    if not r.get_point().isspace() and not r.get_point() in ',]}':
+                        r.last()
+                        s += '\\'
+                        s += r.get_point()
+                        continue
+                    else:
+                        r.last()
+                        token.type = Token.STRING
+                        break
         if i == ':' and not stringStatus:
             break
         s += i


### PR DESCRIPTION
### 1.数字格式读取(issue#3)
由于存在诸如`8b`等数字格式，需要数字与字符串拼接，但是原先在判定数字后的字符是否为末尾时没有考虑`}`

### 2.引号未配置转义符时读取错误(issue#2)
添加对引号后是否为行末的判断，非行末时判定为无转义符的非法引号，手动增加转义符

### 示例文本
[此示例包含上述两种错误](https://pastebin.ubuntu.com/p/Z7RM2G8Qbs/)